### PR TITLE
Support reauth on identity endpoints with a base path

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -110,7 +110,7 @@ func v2auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 	if options.AllowReauth {
 		client.ReauthFunc = func() error {
 			client.TokenID = ""
-			return AuthenticateV2(client, options)
+			return v2auth(client, endpoint, options)
 		}
 	}
 	client.TokenID = token.ID
@@ -168,7 +168,7 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 	if options.AllowReauth {
 		client.ReauthFunc = func() error {
 			client.TokenID = ""
-			return AuthenticateV3(client, options)
+			return v3auth(client, endpoint, options)
 		}
 	}
 	client.EndpointLocator = func(opts gophercloud.EndpointOpts) (string, error) {


### PR DESCRIPTION
Fix re-authentication to use the correct endpoint when the identity endpoint has a base path (e.g. https://keystone.example.com/somepath/v2.0)

So far the reauth function ignores the endpoint path and ends up using the wrong endpoint (in the example above, it will try to reauth against https://keystone.example.com/v2.0)
